### PR TITLE
encoding/json: add UseAllKeys() Decoder option to reject unknown keys

### DIFF
--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -35,6 +35,10 @@ func NewDecoder(r io.Reader) *Decoder {
 // Number instead of as a float64.
 func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
 
+// UseAllKeys causes the Decoder's unmarshal to return an error when
+// the input JSON has keys that do not match to struct fields
+func (dec *Decoder) UseAllKeys() { dec.d.useAllKeys = true }
+
 // Decode reads the next JSON-encoded value from its
 // input and stores it in the value pointed to by v.
 //


### PR DESCRIPTION
It is currently not possible to perform strict input validation in JSON unmarshaling. By design unrecognized keys are silently ignored. This patch adds an option to the Decoder that will
collect all keys that do not have a matching struct field. When this option is enabled the Unmarshal() function emits an error when unused keys are detected.

The encoding/json unit tests have been refactored such that each test case is run twice: once with UseAllKeys() disabled and once with UseAllKeys() enabled. The majority of test cases produce identical output under the two scenarios. For the handful of test cases that produce different output, the expected output or error has been updated in those test cases.
